### PR TITLE
Fix the regexp_like trans to RLIKE function

### DIFF
--- a/sqlglot/dialects/clickzetta.py
+++ b/sqlglot/dialects/clickzetta.py
@@ -10,7 +10,6 @@ from sqlglot.dialects.mysql import MySQL
 from sqlglot.dialects.postgres import Postgres
 from sqlglot.dialects.spark import Spark
 from sqlglot.tokens import Tokenizer, TokenType
-from sqlglot.trie import new_trie
 
 logger = logging.getLogger("sqlglot")
 
@@ -280,6 +279,7 @@ class ClickZetta(Spark):
             exp.RegexpExtract: regexp_extract_sql,
             exp.DayOfWeek: adjust_day_of_week,
             exp.Group: transforms.preprocess([_transform_group_sql]),
+            exp.RegexpLike: rename_func("RLIKE"),
         }
 
         # def distributedbyproperty_sql(self, expression: exp.DistributedByProperty) -> str:

--- a/tests/dialects/test_clickzetta.py
+++ b/tests/dialects/test_clickzetta.py
@@ -279,6 +279,12 @@ select j from a""",
             read={'presto': "select regexp_extract(\"a\", 'a|b|c', 1)"}
         )
 
+        # rlike
+        self.validate_all(
+            r"SELECT RLIKE('1a 2b 14m', '\\d+b')",
+            read={'presto': "SELECT regexp_like('1a 2b 14m', '\d+b')"}
+        )
+
         # day_of_week
         os.environ['READ_DIALECT'] = 'presto'
         self.validate_all(


### PR DESCRIPTION
'presto': `SELECT regexp_like('1a 2b 14m', '\d+b')`
transpile to:
```
SELECT RLIKE('1a 2b 14m', '\d+b')
```