### PR TITLE
Rebase branch into main and fix the Starrocks to Clickzetta transpile

### DIFF
--- a/sqlglot/dialects/clickzetta.py
+++ b/sqlglot/dialects/clickzetta.py
@@ -4,7 +4,7 @@ import logging
 import typing as t
 
 from sqlglot import exp, transforms
-from sqlglot.dialects import MySQL
+from sqlglot.dialects.mysql import MySQL
 from sqlglot.dialects.dialect import (
     rename_func,
     if_sql, )

--- a/tests/dialects/test_clickzetta.py
+++ b/tests/dialects/test_clickzetta.py
@@ -220,8 +220,8 @@ select j from a""",
             read={'presto': r"select DATE_FORMAT(CURRENT_DATE, '%x-%v %a %W')"}
         )
         self.validate_all(
-            "SELECT CAST(DATE_FORMAT_MYSQL(TIMESTAMP('2024-08-22 14:53:12'), '%Y-%m-%d') AS DATE)",
-            read={'presto': r"""SELECT CAST(date_format(timestamp('2024-08-22 14:53:12'), '%Y-%m-%d') AS DATE);"""}
+            "SELECT CAST(DATE_FORMAT_MYSQL(CAST('2024-08-22 14:53:12' AS TIMESTAMP), '%Y-%m-%d') AS DATE)",
+            read={'presto': r"""SELECT CAST(date_format(cast('2024-08-22 14:53:12' as TIMESTAMP), '%Y-%m-%d') AS DATE)"""}
         )
         self.validate_all(
             "SELECT TIMESTAMP('2024-08-22 14:53:12'), DATE_FORMAT_MYSQL(TIMESTAMP('2024-08-22 "


### PR DESCRIPTION
This PR adds support for the following:
- Fix the breaking changes caused by merging main, including `grouping set, cube, rollup` syntax affected by group sql and `exp.FromISO8601Timestamp` to `cast(expr AS TIMESTAMP)` 

- _parse_json support JSON '' syntax and `parse_json` function 

- json_extract support, If the literal starts with $., use JSON_EXTRACT directly 

- exp.Chr to `CHAR(char_expr AS INT)` 

- exp.ArrayAgg to `COLLECT_LIST` - ceiling to ceil