### PR TITLE
clear is_read_dialect hardcode and supported create table to generate

### DIFF
--- a/local_clickzetta_settings.py
+++ b/local_clickzetta_settings.py
@@ -1,0 +1,75 @@
+import sys
+from sqlglot import exp
+from sqlglot.expressions import Func, IntervalOp
+from sqlglot.parser import Parser
+from sqlglot.dialects.presto import Presto
+from sqlglot.dialects.trino import Trino
+from sqlglot.dialects.athena import Athena
+from sqlglot.dialects.starrocks import StarRocks
+from sqlglot.dialects.doris import Doris
+from sqlglot.dialects.mysql import MySQL
+from sqlglot.dialects.postgres import Postgres
+from sqlglot.dialects.redshift import Redshift
+
+# Note: This workaround only allows the syntax that has been adapted to the Source Dialect of Clickzetta to be hacked.
+# Anything that can be solved through expression will not be allowed here.
+for dialect in [MySQL, Presto, Trino, Athena, StarRocks, Doris]:
+    dialect.Parser.FUNCTIONS["DATE_FORMAT"] = lambda args: exp.Anonymous(this="DATE_FORMAT_MYSQL",
+                                                                         expressions=args)
+    dialect.Parser.FUNCTIONS["AES_DECRYPT"] = lambda args: exp.Anonymous(this="AES_DECRYPT_MYSQL",
+                                                                         expressions=args)
+    dialect.Parser.FUNCTIONS["AES_ENCRYPT"] = lambda args: exp.Anonymous(this="AES_ENCRYPT_MYSQL",
+                                                                         expressions=args)
+for dialect in [Postgres, Redshift]:
+    dialect.Parser.FUNCTIONS["TO_CHAR"] = lambda args: exp.Anonymous(this="DATE_FORMAT_PG", expressions=args)
+
+_parse_select = getattr(Parser, '_parse_select')
+
+
+def preprocess_parse_select(self, *args, **kwargs):
+    expression = _parse_select(self, *args, **kwargs)
+    if not expression:
+        return expression
+    # source dialect
+    read_dialect = self.dialect.__module__.split(".")[-1].upper()
+    _normalize_tuple_comparisons(expression, read_dialect)
+    return expression
+
+# We added return_type to DateAdd to enable the generator to choose timestamp_or_date_add or date_add
+# translation based on return_type
+class DateAdd(Func, IntervalOp):
+    arg_types = {"this": True, "expression": True, "unit": False, "return_type": False}
+
+
+module = sys.modules['sqlglot.parser']
+setattr(module, 'DateAdd', DateAdd)
+setattr(Parser, '_parse_select', preprocess_parse_select)
+
+
+# According to #4042 suggestion, we create a custom transformation to handle presto tuple comparisons
+# https://github.com/tobymao/sqlglot/issues/4042
+def _normalize_tuple_comparisons(expression: exp.Expression, read_dialect: str):
+    if read_dialect != 'PRESTO':
+        return expression
+    for tup in expression.find_all(exp.Tuple):
+        if not isinstance(tup.parent, exp.Binary) or not isinstance(tup.parent, exp.Predicate):
+            continue
+        binary = tup.parent
+        left, right = binary.this, binary.expression
+        if not isinstance(left, exp.Tuple) or not isinstance(right, exp.Tuple):
+            continue
+        left_exprs = left.expressions
+        right_exprs = right.expressions
+        for i, (left_expr, right_expr) in enumerate(zip(left_exprs, right_exprs), start=1):
+            alias = f"col{i}"
+            if not isinstance(left_expr, exp.Alias):
+                left_exprs[i - 1] = exp.Alias(this=left_expr,
+                                              alias=exp.to_identifier(alias))
+            else:
+                left_exprs[i - 1].set("alias", exp.to_identifier(alias))
+
+            if not isinstance(right_expr, exp.Alias):
+                right_exprs[i - 1] = exp.Alias(this=right_expr,
+                                               alias=exp.to_identifier(alias))
+            else:
+                right_exprs[i - 1].set("alias", exp.to_identifier(alias))

--- a/sqlglot/dialects/clickzetta.py
+++ b/sqlglot/dialects/clickzetta.py
@@ -70,9 +70,6 @@ def _anonymous_func(self: ClickZetta.Generator, expression: exp.Anonymous) -> st
         return f"DAYOFYEAR({self.sql(expression.expressions[0])})"
     elif expression.this.upper() == 'YOW' or expression.this.upper() == 'YEAR_OF_WEEK':
         return f"YEAROFWEEK({self.sql(expression.expressions[0])})"
-    # TODO: temporary workaround for presto 'select current_timezone()'
-    elif expression.this.upper() == 'CURRENT_TIMEZONE':
-        return f"'Asia/Shanghai'"
     elif expression.this.upper() == 'GROUPING':
         return f"GROUPING_ID({self.expressions(expression, flat=True)})"
     elif expression.this.upper() == 'MURMUR_HASH3_32':

--- a/sqlglot/dialects/clickzetta.py
+++ b/sqlglot/dialects/clickzetta.py
@@ -3,31 +3,23 @@ from __future__ import annotations
 import logging
 import typing as t
 
-from sqlglot import exp, transforms
-from sqlglot.dialects.mysql import MySQL
+from sqlglot import exp
+from sqlglot import transforms
 from sqlglot.dialects.dialect import (
     rename_func,
-    if_sql, )
-from sqlglot.dialects.postgres import Postgres
+    if_sql,
+)
 from sqlglot.dialects.spark import Spark
 from sqlglot.tokens import Tokenizer, TokenType
 
 logger = logging.getLogger("sqlglot")
 
-def is_read_dialect(target: str) -> bool:
-    target = target.upper()
-    import os
-    read_dialect = os.environ.get('READ_DIALECT')
-    if not read_dialect:
-        return False
-    if target == 'MYSQL' and read_dialect.upper() in ['MYSQL', 'PRESTO', 'TRINO', 'ATHENA', 'STARROCKS', 'DORIS']:
-        return True
-    if target == 'POSTGRES' and read_dialect.upper() in ['POSTGRES', 'REDSHIFT']:
-        return True
-    if target == read_dialect.upper():
-        return True
+try:
+    import local_clickzetta_settings
+except ImportError as e:
+    logger.warning(f'Failed to import local_clickzetta_settings, reason: {e}')
+    pass
 
-    return False
 
 def _transform_create(expression: exp.Expression) -> exp.Expression:
     """Remove index column constraints.
@@ -51,17 +43,12 @@ def _groupconcat_to_wmconcat(self: ClickZetta.Generator, expression: exp.GroupCo
     return f"WM_CONCAT({sep}, {self.sql(this)})"
 
 def _anonymous_func(self: ClickZetta.Generator, expression: exp.Anonymous) -> str:
-    if expression.this.upper() == 'DATETIME':
-        # in MaxCompute, datetime(col) is an alias of cast(col as datetime)
-        return f"{self.sql(expression.expressions[0])}::TIMESTAMP"
-    elif expression.this.upper() == 'GETDATE':
+    if expression.this.upper() == 'GETDATE':
         return f"CURRENT_TIMESTAMP()"
     elif expression.this.upper() == 'LAST_DAY_OF_MONTH':
         return f"LAST_DAY({self.sql(expression.expressions[0])})"
     elif expression.this.upper() == 'TO_ISO8601':
         return f"DATE_FORMAT({self.sql(expression.expressions[0])}, 'yyyy-MM-dd\\\'T\\\'hh:mm:ss.SSSxxx')"
-    elif expression.this.upper() == 'AES_DECRYPT' and is_read_dialect('mysql'):
-        return f"AES_DECRYPT_MYSQL({self.sql(expression.expressions[0])}, {self.sql(expression.expressions[1])})"
     elif expression.this.upper() == 'MAP_AGG':
         return f"MAP_FROM_ENTRIES(COLLECT_LIST(STRUCT({self.expressions(expression)})))"
     elif expression.this.upper() == 'JSON_ARRAY_GET':
@@ -188,62 +175,27 @@ def unnest_to_values(self: ClickZetta.Generator, expression: exp.Unnest):
     return expression.sql()
 
 
-def time_to_str(self: ClickZetta.Generator, expression: exp.TimeToStr):
-    this = self.sql(expression, "this")
-    if is_read_dialect('mysql'):
-        _format = self.format_time(expression, inverse_time_mapping=MySQL.INVERSE_TIME_MAPPING,
-                                   inverse_time_trie=MySQL.INVERSE_TIME_TRIE)
-        return f"DATE_FORMAT_MYSQL({this}, {_format})"
-    elif is_read_dialect('postgres'):
-        _format = self.format_time(expression, inverse_time_mapping=Postgres.INVERSE_TIME_MAPPING,
-                                   inverse_time_trie=Postgres.INVERSE_TIME_TRIE)
-        return f"DATE_FORMAT_PG({this}, {_format})"
-
-    # fallback to hive implementation
-    _format = self.format_time(expression)
-    return f"DATE_FORMAT({this}, {_format})"
-
-
-def fill_tuple_with_column_name(self: ClickZetta.Generator, expression: exp.Tuple) -> str:
-    if (not isinstance(expression.parent, exp.Values) and not isinstance(expression.parent.parent, exp.Group)
-            and is_read_dialect('mysql')):
-        elements = []
-        for i, e in enumerate(expression.expressions):
-            elements.append(f'{self.sql(e)} AS __c{i+1}')
-        return f"({', '.join(elements)})"
-    else:
-        return f"({self.expressions(expression, flat=True)})"
-
 def date_add_sql(self: ClickZetta.Generator, expression: exp.DateAdd) -> str:
-    # this is a workaround since date_add in presto should be parsed as TsOrDsAdd
+    """
+    Convert date_add to TIMESTAMP_OR_DATE_ADD.
+
+    Note the currently difference between `exp.DateAdd` and `exp.TimestampAdd` and `exp.Anonymous(date_add)`
+    | dialect | sql example | expression | return type |
+    |---------|--------------|------------|--------------|
+    | starrocks | select date_add('2010-11-30 23:59:59', INTERVAL 2 DAY) | exp.DateAdd | timestamp or date |
+    | presto | select date_add('2010-11-30 23:59:59', INTERVAL 2 DAY) | exp.DateAdd | timestamp or date |
+    | spark | select date_add('2024-01-01', 1) | exp.Anonymous | date |
+    | spark | select dateadd(DAY, 1, '2024-01-01') | exp.TimestampAdd | timestamp |
+    """
     # https://prestodb.io/docs/current/functions/datetime.html#date_add
-    if is_read_dialect('presto'):
-        unit = expression.args.get('unit')
-        if isinstance(unit, exp.Var):
-            unit_str = f"'{self.sql(unit)}'"
-        else:
-            unit_str = self.sql(unit)
-        return f"TIMESTAMP_OR_DATE_ADD({unit_str}, {self.sql(expression.expression)}, {self.sql(expression.this)})"
-    return f"DATEADD({self.sql(expression.args.get('unit'))}, {self.sql(expression.expression)}, {self.sql(expression.this)})"
-
-def regexp_extract_sql(self: ClickZetta.Generator, expression: exp.RegexpExtract):
-    bad_args = list(filter(expression.args.get, ("position", "occurrence", "parameters")))
-    if bad_args:
-        self.unsupported(f"REGEXP_EXTRACT does not support the following arg(s): {bad_args}")
-
-    group = expression.args.get('group')
-    if not group and is_read_dialect('presto'):
-        return f"REGEXP_EXTRACT({self.sql(expression.this)}, {self.sql(expression.expression)}, 0)"
-
-    return self.func(
-        "REGEXP_EXTRACT", expression.this, expression.expression, expression.args.get('group')
-    )
-
-def adjust_day_of_week(self: ClickZetta.Generator, expression: exp.DayOfWeek):
-    if is_read_dialect('presto'):
-        return f'DAYOFWEEK_ISO({self.sql(expression.this)})'
+    unit = expression.args.get('unit')
+    if not unit:
+        unit = exp.Literal.string("DAY")
+    if isinstance(unit, exp.Var):
+        unit_str = f"'{self.sql(unit)}'"
     else:
-        return f'DAYOFWEEK({self.sql(expression.this)})'
+        unit_str = self.sql(unit)
+    return f"TIMESTAMP_OR_DATE_ADD({unit_str}, {self.sql(expression.expression)}, {self.sql(expression.this)})"
 
 
 def _transform_group_sql(expression: exp.Expression) -> exp.Expression:
@@ -314,11 +266,15 @@ class ClickZetta(Spark):
         }
 
     class Parser(Spark.Parser):
-        pass
+        PROPERTY_PARSERS = {
+            **Spark.Parser.PROPERTY_PARSERS,
+            # ClickZetta has properties syntax similar to MySQL. e.g. PROPERTIES('key1'='value')
+            "PROPERTIES": lambda self: self._parse_wrapped_properties(),
+        }
 
     class Generator(Spark.Generator):
-
         RESERVED_KEYWORDS = {'all', 'user', 'to', 'check', 'order'}
+        WITH_PROPERTIES_PREFIX = "PROPERTIES"
 
         TYPE_MAPPING = {
             **Spark.Generator.TYPE_MAPPING,
@@ -340,11 +296,14 @@ class ClickZetta(Spark):
             exp.DataType.Type.SERIAL: "INT",
             exp.DataType.Type.SMALLSERIAL: "SMALLINT",
             exp.DataType.Type.BIGDECIMAL: "DECIMAL",
+            # starrocks decimal types
+            exp.DataType.Type.DECIMAL32: "DECIMAL",
+            exp.DataType.Type.DECIMAL64: "DECIMAL",
+            exp.DataType.Type.DECIMAL128: "DECIMAL",
         }
 
         PROPERTIES_LOCATION = {
             **Spark.Generator.PROPERTIES_LOCATION,
-            # exp.DistributedByProperty: exp.Properties.Location.POST_SCHEMA,
             exp.PrimaryKey: exp.Properties.Location.POST_NAME,
             exp.EngineProperty: exp.Properties.Location.POST_SCHEMA,
         }
@@ -358,7 +317,10 @@ class ClickZetta(Spark):
                     unnest_to_explode,
                 ]
             ),
+            # in MaxCompute, datetime(col) is an alias of cast(col as datetime)
+            exp.Datetime: rename_func("TO_TIMESTAMP"),
             exp.DefaultColumnConstraint: lambda self, e: '',
+            exp.DuplicateKeyProperty: lambda self, e: '',
             exp.OnUpdateColumnConstraint: lambda self, e: '',
             exp.AutoIncrementColumnConstraint: lambda self, e: '',
             exp.CollateColumnConstraint: lambda self, e: '',
@@ -373,9 +335,7 @@ class ClickZetta(Spark):
             exp.UnixToTime: lambda self, e: self.func(
                 "CONVERT_TIMEZONE", "'UTC+0'", e.this
             ),
-            # exp.DistributedByProperty: lambda self, e: self.distributedbyproperty_sql(e),
             exp.EngineProperty: lambda self, e: '',
-            exp.TimeToStr: time_to_str,
             exp.Pow: rename_func("POW"),
             exp.ApproxQuantile: rename_func("APPROX_PERCENTILE"),
             exp.JSONFormat: rename_func("TO_JSON"),
@@ -384,11 +344,9 @@ class ClickZetta(Spark):
             exp.If: if_sql(false_value=exp.Null()),
             exp.Unnest: unnest_to_values,
             exp.Try: lambda self, e: self.sql(e, "this"),
-            exp.Tuple: fill_tuple_with_column_name,
             exp.GenerateSeries: rename_func("SEQUENCE"),
             exp.DateAdd: date_add_sql,
-            exp.RegexpExtract: regexp_extract_sql,
-            exp.DayOfWeek: adjust_day_of_week,
+            exp.DayOfWeekIso: lambda self, e: self.func("DAYOFWEEK_ISO", e.this),
             exp.Group: transforms.preprocess([_transform_group_sql]),
             exp.RegexpLike: rename_func("RLIKE"),
             exp.JSONExtract: lambda self, e: _json_extract("JSON_EXTRACT", self, e),
@@ -396,13 +354,6 @@ class ClickZetta(Spark):
             exp.ArrayAgg: rename_func("COLLECT_LIST"),
             exp.FromISO8601Timestamp: lambda self, e: f"{self.sql(exp.cast(e.this, exp.DataType.Type.TIMESTAMP))}",
         }
-
-        # def distributedbyproperty_sql(self, expression: exp.DistributedByProperty) -> str:
-        #     expressions = self.expressions(expression, key="expressions", flat=True)
-        #     sorted_by = self.expressions(expression, key="sorted_by", flat=True)
-        #     sorted_by = f" SORTED BY ({sorted_by})" if sorted_by else ""
-        #     buckets = self.sql(expression, "buckets")
-        #     return f"HASH CLUSTERED BY ({expressions}){sorted_by} INTO {buckets} BUCKETS"
 
         def datatype_sql(self, expression: exp.DataType) -> str:
             """Remove unsupported type params from int types: eg. int(10) -> int
@@ -414,27 +365,30 @@ class ClickZetta(Spark):
                 else type_value
             )
             if type_value in exp.DataType.INTEGER_TYPES or \
-                type_value in {
-                    exp.DataType.Type.UTINYINT,
-                    exp.DataType.Type.USMALLINT,
-                    exp.DataType.Type.UMEDIUMINT,
-                    exp.DataType.Type.UINT,
-                    exp.DataType.Type.UINT128,
-                    exp.DataType.Type.UINT256,
-
-                    exp.DataType.Type.ENUM,
-               }:
+                    type_value in {
+                exp.DataType.Type.UTINYINT,
+                exp.DataType.Type.USMALLINT,
+                exp.DataType.Type.UMEDIUMINT,
+                exp.DataType.Type.UINT,
+                exp.DataType.Type.UINT128,
+                exp.DataType.Type.UINT256,
+                exp.DataType.Type.ENUM,
+                exp.DataType.Type.FLOAT,
+                exp.DataType.Type.DOUBLE,
+            }:
                 return type_sql
             return super().datatype_sql(expression)
 
-        def tochar_sql(self, expression: exp.ToChar) -> str:
-            this = expression.args.get('this')
-            format = expression.args.get('format')
-            if format:
-                format_str = str(format).replace('mm', 'MM').replace('mi', 'mm')
-                return f"DATE_FORMAT_PG({self.sql(this)}, {self.sql(format_str)})"
-
-            return super().tochar_sql(expression)
+        def distributedbyproperty_sql(self, expression: exp.DistributedByProperty) -> str:
+            expressions = self.expressions(expression, key="expressions", flat=True)
+            order = self.expressions(expression, key="order", flat=True)
+            order = f" SORTED BY {order}" if order else ""
+            buckets = self.sql(expression, "buckets")
+            if not buckets:
+                self.unsupported(
+                    "DistributedByHash without buckets, clickzetta requires a number of buckets"
+                )
+            return f"CLUSTERED BY ({expressions}){order} INTO {buckets} BUCKETS"
 
         def preprocess(self, expression: exp.Expression) -> exp.Expression:
             """Apply generic preprocessing transformations to a given expression."""

--- a/tests/dialects/test_clickzetta.py
+++ b/tests/dialects/test_clickzetta.py
@@ -304,11 +304,6 @@ select j from a""",
             read={'presto': "select now() at time zone 'UTC'"}
         )
         self.validate_all(
-            "SELECT 'Asia/Shanghai'",
-            read={'presto': "select current_timezone()"}
-        )
-        # TODO temporary workaround for presto 'select current_timezone()'
-        self.validate_all(
             "SELECT DAYOFWEEK(TO_DATE(d))",
             read={'spark': "select dayofweek(d)"}
         )

--- a/tests/dialects/test_clickzetta.py
+++ b/tests/dialects/test_clickzetta.py
@@ -28,33 +28,104 @@ class TestClickzetta(Validator):
                 "clickzetta": "SELECT JSON_EXTRACT(`to`, '$.billing_zone') AS to_billing_zone",
               },
         )
+        self.validate_all(
+            "select json_extract(to, '$.billing_zone') as to_billing_zone",
+            write={
+                "clickzetta": "SELECT JSON_EXTRACT(`to`, '$.billing_zone') AS to_billing_zone",
+              },
+        )
 
     def test_ddl_types(self):
+        starrocks_ddl_sqls = [
+            ("DISTRIBUTED BY HASH (col1) BUCKETS 1", "CLUSTERED BY (col1) INTO 1 BUCKETS"),
+            ("DISTRIBUTED BY HASH (col1) BUCKETS 1 ORDER BY (col1)", "CLUSTERED BY (col1) SORTED BY (col1) INTO 1 BUCKETS"),
+            ("DISTRIBUTED BY HASH (col1) BUCKETS 1 PROPERTIES ('replication_num'='1')",
+             "CLUSTERED BY (col1) INTO 1 BUCKETS PROPERTIES ('replication_num'='1')"),
+            ("DUPLICATE KEY (col1, col2) DISTRIBUTED BY HASH (col1) BUCKETS 1", "CLUSTERED BY (col1) INTO 1 BUCKETS"),
+            ("PARTITION BY (col1)", "PARTITIONED BY (col1)"),
+        ]
+
+        for prep in starrocks_ddl_sqls:
+            with self.subTest(f"Testing create scheme: {prep}"):
+                self.validate_all(f"CREATE TABLE foo (col1 BIGINT, col2 BIGINT) {prep[1]}",
+                                  read={"starrocks": f"CREATE TABLE foo (col1 BIGINT, col2 BIGINT) {prep[0]}"})
+
+        # Test the different wider DECIMAL types
         self.validate_all(
-            'CREATE TABLE foo (a INT)',
-            read={'postgres': 'create table foo (a serial)'}
+            "CREATE TABLE foo (col0 DECIMAL(9, 1), col1 DECIMAL(9, 1), col2 DECIMAL(18, 10), col3 DECIMAL(38, 10)) CLUSTERED BY (col1) INTO 1 BUCKETS",
+            read={
+                "starrocks": "CREATE TABLE foo (col0 DECIMAL(9, 1), col1 DECIMAL32(9, 1), col2 DECIMAL64(18, 10), col3 DECIMAL128(38, 10)) DISTRIBUTED BY HASH (col1) BUCKETS 1"}
         )
+        types = [("SERIAL", "INT"), ("BIGSERIAL", "BIGINT"), ("ENUM", "STRING"), ("INT DEFAULT 0", "INT"),]
+        for type in types:
+            with self.subTest(f"Testing covert postgres type: {type}"):
+                self.validate_all(
+                    f"CREATE TABLE foo (a {type[1]})",
+                    read={
+                        "postgres": f"CREATE TABLE foo (a {type[0]})",
+                    },
+                )
+
+        # Test the mysql type
+        types = [("DECIMAL UNSIGNED", "DECIMAL"), ("LONGTEXT", "STRING")]
+        for type in types:
+            with self.subTest(f"Testing covert mysql type: {type}"):
+                self.validate_all(
+                    f"CREATE TABLE foo (a {type[1]})",
+                    read={
+                        "mysql": f"CREATE TABLE foo (a {type[0]})",
+                    },
+                )
+
+        # Test the starrocks type
+        types = [("INT(11)", "INT"), ("INT(11) NOT NULL", "INT NOT NULL"),
+                 ("SMALLINT(8)", "SMALLINT"), ("BIGINT(20)", "BIGINT"), ("datetime", "TIMESTAMP"),
+                 ("FLOAT(10, 2)", "FLOAT"), ("DOUBLE(10, 2)", "DOUBLE"),("DECIMAL(10, 2)", "DECIMAL(10, 2)"),
+                 ("DECIMAL32(9, 1)", "DECIMAL(9, 1)"),("DECIMAL64(18, 10)", "DECIMAL(18, 10)"),
+                 ("DECIMAL128(38, 10)", "DECIMAL(38, 10)")]
+        for type in types:
+            with self.subTest(f"Testing covert starrocks type: {type}"):
+                self.validate_all(
+                    f"CREATE TABLE foo (a {type[1]})",
+                    read={
+                        "starrocks": f"CREATE TABLE foo (a {type[0]})",
+                    },
+                )
+
+        # Test create table with primary key, duplicate key, partitioned by, clustered by, sorted by and properties
         self.validate_all(
-            'CREATE TABLE foo (a BIGINT)',
-            read={'postgres': 'create table foo (a bigserial)'}
-        )
-        self.validate_all(
-            'CREATE TABLE foo (a DECIMAL)',
-            read={'mysql': 'create table foo (a decimal unsigned)'}
-        )
-        self.validate_all(
-            'CREATE TABLE foo (a STRING)',
-            read={'mysql': 'create table foo (a longtext)'}
-        )
-        self.validate_all(
-            'CREATE TABLE foo (a STRING)',
-            read={'postgres': 'create table foo (a enum)'}
-        )
+            "CREATE TABLE IF NOT EXISTS `tbl` (`tenantid` VARCHAR(1048576) COMMENT '', `create_day` DATE NOT NULL COMMENT '', `shopsite` VARCHAR(65533) NOT NULL COMMENT 'shopsite', `id` VARCHAR(65533) NOT NULL COMMENT 'shopsite id', `price` DECIMAL(38, 10) COMMENT 'price', `seq` INT COMMENT 'order', `use_status` SMALLINT COMMENT '0,1', `created_user` BIGINT COMMENT 'create user', `created_time` TIMESTAMP COMMENT 'create time', PRIMARY KEY (`tenantid`, `shopsite`, `id`)) COMMENT 'OLAP' PARTITIONED BY (`tenantid`) CLUSTERED BY (`tenantid`, `shopsite`, `id`) SORTED BY (`tenantid`, `shopsite`, `id`) INTO 10 BUCKETS PROPERTIES ('replication_num'='1', 'in_memory'='false', 'enable_persistent_index'='false', 'replicated_storage'='false', 'storage_medium'='HDD', 'compression'='LZ4')",
+            read={"starrocks": """CREATE TABLE IF NOT EXISTS `tbl` (
+    `tenantid` varchar(1048576) NULL COMMENT "",
+    `create_day` date NOT NULL COMMENT "",
+    `shopsite` varchar(65533) NOT NULL COMMENT "shopsite",
+    `id` varchar(65533) NOT NULL COMMENT "shopsite id",
+    `price` decimal128(38, 10) NULL COMMENT "price",
+    `seq` int(11) NULL COMMENT "order",
+    `use_status` smallint(6) NULL COMMENT "0,1",
+    `created_user` bigint(20) NULL COMMENT "create user",
+    `created_time` datetime NULL COMMENT "create time",
+) ENGINE=OLAP
+DUPLICATE KEY(tenantid)
+PRIMARY KEY(`tenantid`, `shopsite`, `id`)
+COMMENT "OLAP"
+PARTITION BY (`tenantid`)
+DISTRIBUTED BY HASH(`tenantid`, `shopsite`, `id`) BUCKETS 10
+ORDER BY (`tenantid`, `shopsite`, `id`)
+PROPERTIES (
+    "replication_num" = "1",
+    "in_memory" = "false",
+    "enable_persistent_index" = "false",
+    "replicated_storage" = "false",
+    "storage_medium" = "HDD",
+    "compression" = "LZ4"
+)"""})
 
     def test_dml(self):
         self.validate_all(
             "INSERT INTO a.b.c (`x`, `y`, `z`) VALUES (1, 'hello', CAST('2024-07-23 15:17:12' AS TIMESTAMP))",
-            read={'presto': "insert into a.b.c (\"x\", \"y\", \"z\") values (1, 'hello', timestamp '2024-07-23 15:17:12')"}
+            read={
+                'presto': "insert into a.b.c (\"x\", \"y\", \"z\") values (1, 'hello', timestamp '2024-07-23 15:17:12')"}
         )
 
     def test_functions(self):
@@ -62,6 +133,43 @@ class TestClickzetta(Validator):
             "select approx_percentile(a, 0.9)",
             write={
                 "clickzetta": "SELECT APPROX_PERCENTILE(a, 0.9)",
+            }
+        )
+        self.validate_all(
+            "SELECT WM_CONCAT(',', x)",
+            read={
+                "postgres": "SELECT STRING_AGG(x, ',')"
+            },
+            write={
+                "clickzetta": "SELECT WM_CONCAT(',', x)",
+            }
+        )
+        self.validate_all(
+            """SELECT DATE_FORMAT_PG(CURRENT_TIMESTAMP(), 'yyyy-"Q"Q')""",
+            read={
+                "postgres": """select to_char(current_timestamp, 'yyyy-"Q"Q')"""
+            },
+            write={
+                "clickzetta": """SELECT DATE_FORMAT_PG(CURRENT_TIMESTAMP(), 'yyyy-"Q"Q')""",
+            }
+        )
+        self.validate_all(
+            "SELECT DATE_FORMAT_PG(CONVERT_TIMEZONE('America/Toronto', CONVERT_TIMEZONE('UTC+0', 1692759280)), 'yyyy-MM-dd HH24:MI:ss')",
+            read={
+                "postgres": "select to_char(to_timestamp(1692759280) at time zone 'America/Toronto', 'yyyy-MM-dd HH24:MI:ss');"
+            },
+            write={
+                "clickzetta": "SELECT DATE_FORMAT_PG(CONVERT_TIMEZONE('America/Toronto', CONVERT_TIMEZONE('UTC+0', 1692759280)), 'yyyy-MM-dd HH24:MI:ss')",
+            }
+        )
+        # TODO Need to add a case for to_timestamp(1693365993000/1000) when / is replaced with `div` in CONVERT_TIMEZONE.
+        self.validate_all(
+            "SELECT CONVERT_TIMEZONE('UTC+0', 1693365993)",
+            read={
+                "postgres": "select to_timestamp(1693365993)"
+            },
+            write={
+                "clickzetta": "SELECT CONVERT_TIMEZONE('UTC+0', 1693365993)",
             }
         )
         self.validate_all(
@@ -142,8 +250,8 @@ select j from a""",
             """SELECT CAST(JSON_EXTRACT(JSON '{"a": 1}', '$.a') AS STRING)""",
         )
         self.validate_all(
-            """SELECT CAST(PARSE_JSON(fieldvalue)['00000000-0000-0000-0000-00000000'] AS STRING) AS `编号` FROM VALUES ('{"00000000-0000-0000-0000-00000000":"编号01"}') AS t(fieldvalue)""",
-            read={'starrocks': """select cast(parse_json(fieldvalue) -> '00000000-0000-0000-0000-00000000' as varchar ) as `编号` from values('{"00000000-0000-0000-0000-00000000":"编号01"}') as t(fieldvalue)"""}
+            """SELECT CAST(fieldvalue['00000000-0000-0000-0000-00000000'] AS STRING) AS `code` FROM (SELECT JSON '{"00000000-0000-0000-0000-00000000":"code01"}' AS fieldvalue) AS t""",
+            read={'starrocks': """SELECT CAST(fieldvalue -> '00000000-0000-0000-0000-00000000' AS VARCHAR) AS `code` FROM (SELECT PARSE_JSON('{"00000000-0000-0000-0000-00000000":"code01"}') as fieldvalue) as t"""}
         )
         self.validate_all(
             """SELECT CAST(JSON_EXTRACT(JSON '{"a": 1}', '$.a') AS STRING)""",
@@ -162,12 +270,18 @@ select j from a""",
             read={'starrocks': "select array_agg(pv) from values(33),(334),(3),(6),(2) as t(pv)"}
         )
         self.validate_all(
-            "SELECT DATEADD(HOUR, 1, CURRENT_TIMESTAMP())",
-            read={'presto': "select date_add('hour', 1, now())"}
-        )
-        self.validate_all(
             "SELECT TO_TIMESTAMP(a, 'yyyy-MM-dd\\\'T\\\'HH:mm:ss\\\'Z\\\'')",
             read={'presto': "select parse_datetime(a, 'yyyy-MM-dd''T''HH:mm:ss''Z''')"}
+        )
+        # maxCompute DATETIME function
+        self.validate_all(
+            "SELECT TO_TIMESTAMP(a)",
+            read={'': "select DATETIME(a)"}
+        )
+        # maxCompute GETDATE function
+        self.validate_all(
+            "SELECT CURRENT_TIMESTAMP()",
+            read={'': "select GETDATE()"}
         )
         self.validate_all(
             "SELECT CAST('2020-01-01T00:00:00.000Z' AS TIMESTAMP)",
@@ -190,6 +304,11 @@ select j from a""",
             read={'presto': "select now() at time zone 'UTC'"}
         )
         self.validate_all(
+            "SELECT 'Asia/Shanghai'",
+            read={'presto': "select current_timezone()"}
+        )
+        # TODO temporary workaround for presto 'select current_timezone()'
+        self.validate_all(
             "SELECT DAYOFWEEK(TO_DATE(d))",
             read={'spark': "select dayofweek(d)"}
         )
@@ -199,22 +318,17 @@ select j from a""",
         )
 
     def test_read_dialect_related_function(self):
-        import os
-
         # aes_decrypt
-        os.environ['READ_DIALECT'] = 'mysql'
         self.validate_all(
             'SELECT AES_DECRYPT_MYSQL(encrypted_string, key_string)',
             read={'mysql': 'select AES_DECRYPT(encrypted_string, key_string)'}
         )
-        os.environ.pop('READ_DIALECT')
         self.validate_all(
             "SELECT AES_DECRYPT(encrypted_string, key_string)",
             read={'spark': "select AES_DECRYPT(encrypted_string, key_string)"}
         )
 
         # date_format
-        os.environ['READ_DIALECT'] = 'mysql'
         self.validate_all(
             r"SELECT DATE_FORMAT_MYSQL(CURRENT_DATE, '%x-%v %a %W')",
             read={'presto': r"select DATE_FORMAT(CURRENT_DATE, '%x-%v %a %W')"}
@@ -233,7 +347,6 @@ select j from a""",
                     , date_format(timestamp('2024-08-22 14:53:12'), '%e') -- expected: 22
                     , date_format(timestamp('2024-08-22 14:53:12'), '%H %i %s') -- expected: 14 53 12"""}
         )
-        os.environ['READ_DIALECT'] = 'postgres'
         self.validate_all(
             r"SELECT DATE_FORMAT_PG(CURRENT_TIMESTAMP(), 'Mon-dd-YYYY,HH24:mi:ss')",
             read={'postgres': r"select to_char(now(), 'Mon-dd-YYYY,HH24:mi:ss')"}
@@ -253,23 +366,28 @@ select j from a""",
         )
 
         # struct/tuple
-        os.environ['READ_DIALECT'] = 'presto'
-        self.validate_all(
-            "SELECT (1 AS __c1, 'hello' AS __c2) = (2 AS __c1, 'world' AS __c2)",
-            read={'presto': "select (1,'hello') = (2,'world')"}
-        )
+        # https://prestodb.io/docs/current/functions/comparison.html#comparison-operators
+        presto_binary_predicates = [ '=', '!=', '>', '>=', '<', '<=', '<>']
+        spark_binary_predicates = ['=', '<>', '>', '>=', '<', '<=', '<>']
+        for i, predicate in enumerate(presto_binary_predicates):
+            with self.subTest(f"Testing comparison operator: {predicate}"):
+                spark_predicate = spark_binary_predicates[i]
+                self.validate_all(
+                    f"SELECT (1 AS col1, 'hello' AS col2) {spark_predicate} (2 AS col1, 'world' AS col2)",
+                    read={'presto': f"select (1,'hello') {predicate} (2,'world')"}
+                )
+                self.validate_all(
+                    f"SELECT (1, 'hello') {spark_predicate} (2, 'world') FROM (SELECT 1 AS a) AS t(a) GROUP BY GROUPING SETS ((a, a))",
+                    read={
+                        'spark': f"select (1,'hello') {spark_predicate} (2,'world') FROM (SELECT 1 AS a) AS t(a) GROUP BY GROUPING SETS ((a, a))"}
+                )
+        # do not fill as __c? in values tuples
         self.validate_all(
             "SELECT * FROM VALUES (1, 'hello'), (2, 'world')",
             read={'presto': "select * from values (1,'hello'),(2,'world')"}
         )
-        os.environ['READ_DIALECT'] = 'spark'
-        self.validate_all(
-            "SELECT (1, 'hello') = (2, 'world')",
-            read={'spark': "select (1,'hello') = (2,'world')"}
-        )
 
-        # date_add
-        os.environ['READ_DIALECT'] = 'presto'
+        # date_add 3-arg
         self.validate_all(
             "SELECT TIMESTAMP_OR_DATE_ADD(LOWER('hour'), 1 + 2, CURRENT_TIMESTAMP())",
             read={'presto': "select date_add(lower('hour'), 1+2, now())"}
@@ -278,16 +396,31 @@ select j from a""",
             "SELECT TIMESTAMP_OR_DATE_ADD('HOUR', 1 + 2, CURRENT_TIMESTAMP())",
             read={'presto': "select date_add('hour', 1+2, now())"}
         )
-
-        # regexp_extract
-        os.environ['READ_DIALECT'] = 'presto'
         self.validate_all(
-            "SELECT REGEXP_EXTRACT('aaaa', 'a|b|c', 0)",
-            read={'presto': "select regexp_extract('aaaa', 'a|b|c')"}
+            "SELECT TIMESTAMP_OR_DATE_ADD('HOUR', 1, CURRENT_TIMESTAMP())",
+            read={'presto': "select DATE_ADD('hour', 1, now())",
+                  'starrocks': "select DATE_ADD(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)"}
         )
         self.validate_all(
-            "SELECT REGEXP_EXTRACT(`a`, 'a|b|c', 1)",
-            read={'presto': "select regexp_extract(\"a\", 'a|b|c', 1)"}
+            "SELECT TIMESTAMP_OR_DATE_ADD('DAY', 1, CAST('2001-08-22' AS DATE)), TIMESTAMP_OR_DATE_ADD('HOUR', 1, CURRENT_TIMESTAMP())",
+            read={'presto': "select date_add('Day', 1, DATE '2001-08-22'), date_add('hour', 1, current_timestamp)"}
+        )
+        # dateadd 2-arg
+        self.validate_all(
+            "SELECT DATE_ADD(CURRENT_TIMESTAMP(), 1)",
+            read={'spark': "SELECT DATE_ADD(CURRENT_TIMESTAMP(), 1)", }
+        )
+
+        # regexp_extract
+        self.validate_all(
+            "SELECT REGEXP_EXTRACT('aaaa', 'a|b|c', 0)",
+            read={'presto': "select regexp_extract('aaaa', 'a|b|c')"},
+            write={'clickzetta': "SELECT REGEXP_EXTRACT('aaaa', 'a|b|c', 0)"}
+        )
+        self.validate_all(
+            "SELECT REGEXP_EXTRACT(`a`, 'a|b|c')",
+            read={'presto': "SELECT REGEXP_EXTRACT(\"a\", 'a|b|c', 1)"},
+            write={'clickzetta': "SELECT REGEXP_EXTRACT(`a`, 'a|b|c')"}
         )
 
         # rlike
@@ -309,13 +442,10 @@ select j from a""",
         )
 
         # day_of_week
-        os.environ['READ_DIALECT'] = 'presto'
         self.validate_all(
             "SELECT DAYOFWEEK_ISO(d), DAYOFWEEK_ISO(d), DAYOFYEAR(d), DAYOFYEAR(d), YEAROFWEEK(d), YEAROFWEEK(d)",
             read={'presto': "select dow(d), day_of_week(d), doy(d), day_of_year(d), yow(d), year_of_week(d)"}
         )
-
-        os.environ.pop('READ_DIALECT')
 
     def test_group_sql_expression(self):
         self.validate_identity(
@@ -343,9 +473,6 @@ select j from a""",
                 'clickzetta': sql
             },
         )
-
-
-
 
         sql = "SELECT a, AVG(b), AVG(c), COUNT(*) FROM VALUES ('A1', 2, 2), ('A1', 1, 1), ('A2', 3, 3)," + \
               " ('A1', 1, 1) AS tab(a, b, c) GROUP BY ROLLUP (a, b)"


### PR DESCRIPTION

This PR adds support for the following:
- supported starrocks create table statement to generate
- Add local_clickzetta_settings to hack in a way that adds special syntax
- anonymous DATETIME to exp.Datetime
- Added TYPE_MAPPING for starrocks decimal types
- Refactoring the code of TO_TIMESTAMP
- Remove unsupported type params from float,double types