### PR TITLE
[to #CZPDEV-20091] Support bitmap type and UNIQUE KEY for doris

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def sqlglotrs_version():
 
 
 setup(
-    name="sqlglot",
+    name="sqlglot-clickzetta",
     description="An easily customizable SQL parser and transpiler",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/sqlglot/dialects/clickzetta.py
+++ b/sqlglot/dialects/clickzetta.py
@@ -390,6 +390,43 @@ class ClickZetta(Spark):
             "PROPERTIES": lambda self: self._parse_wrapped_properties(),
         }
 
+        def _parse_unique_key_property(self):
+            """Parse UNIQUE KEY syntax as a property."""
+            expressions = self._parse_wrapped_csv(self._parse_id_var, optional=False)
+            return self.expression(exp.UniqueKeyProperty, expressions=expressions)
+
+        def _parse_types(self, check_func=False, schema=False, allow_identifiers=True):
+            """Override to handle BITMAP type."""
+            # Check if current token is BITMAP
+            if self._match_text_seq("BITMAP"):
+                # Map BITMAP to HLLSKETCH internally for consistency
+                return exp.DataType(this=exp.DataType.Type.HLLSKETCH, nested=False)
+            return super()._parse_types(check_func, schema, allow_identifiers)
+
+        def _parse_schema(self, this=None):
+            """Override to handle UNIQUE as a schema-level expression."""
+            schema = super()._parse_schema(this)
+
+            # If schema has UniqueColumnConstraint, convert it to UniqueKeyProperty
+            if schema and hasattr(schema, 'expressions'):
+                # Make a copy of the list to avoid modification during iteration
+                unique_constraints = [e for e in schema.expressions if isinstance(e, exp.UniqueColumnConstraint)]
+                for uc in unique_constraints:
+                    # The UniqueColumnConstraint wraps either a Schema or UniqueKeyProperty
+                    if hasattr(uc, 'this'):
+                        # Remove UniqueColumnConstraint
+                        schema.expressions.remove(uc)
+                        # Extract the UniqueKeyProperty from inside
+                        if isinstance(uc.this, exp.Schema) and hasattr(uc.this, 'expressions'):
+                            # UniqueColumnConstraint(Schema(expressions=[...]))
+                            # We need to create UniqueKeyProperty from the schema's expressions
+                            unique_key = self.expression(exp.UniqueKeyProperty, expressions=uc.this.expressions)
+                            schema.expressions.append(unique_key)
+                        elif isinstance(uc.this, exp.UniqueKeyProperty):
+                            schema.expressions.append(uc.this)
+
+            return schema
+
         def _to_prop_eq(self, expression: exp.Expression, index: int) -> exp.Expression:
             # ClickZetta does not support add alias for STRUCT function, so we need to directly return the expression
             # Otherwise, if is useful, we can use to `named_struct` in the future
@@ -431,6 +468,8 @@ class ClickZetta(Spark):
             exp.DataType.Type.DECIMAL32: "DECIMAL",
             exp.DataType.Type.DECIMAL64: "DECIMAL",
             exp.DataType.Type.DECIMAL128: "DECIMAL",
+            # We map HLLSKETCH to BITMAP for StarRocks/Doris compatibility
+            exp.DataType.Type.HLLSKETCH: "BITMAP",
         }
 
         PROPERTIES_LOCATION = {
@@ -438,6 +477,10 @@ class ClickZetta(Spark):
             exp.PrimaryKey: exp.Properties.Location.POST_NAME,
             exp.EngineProperty: exp.Properties.Location.POST_SCHEMA,
         }
+
+        # Add UniqueKeyProperty location if it exists
+        if hasattr(exp, 'UniqueKeyProperty'):
+            PROPERTIES_LOCATION[exp.UniqueKeyProperty] = exp.Properties.Location.POST_SCHEMA
 
         TRANSFORMS = {
             **Spark.Generator.TRANSFORMS,
@@ -526,6 +569,13 @@ class ClickZetta(Spark):
                     "DistributedByHash without buckets, clickzetta requires a number of buckets"
                 )
             return f"CLUSTERED BY ({expressions}){order} INTO {buckets} BUCKETS"
+
+        def uniquekeyproperty_sql(self, expression: exp.Expression) -> str:
+            """Generate SQL for UniqueKeyProperty."""
+            if hasattr(exp, 'UniqueKeyProperty') and isinstance(expression, exp.UniqueKeyProperty):
+                expressions = self.expressions(expression, key="expressions", flat=True)
+                return f"UNIQUE ({expressions})"
+            return ""
 
         def preprocess(self, expression: exp.Expression) -> exp.Expression:
             """Apply generic preprocessing transformations to a given expression."""

--- a/sqlglot/local_clickzetta_settings.py
+++ b/sqlglot/local_clickzetta_settings.py
@@ -19,7 +19,7 @@ from sqlglot.parser import Parser
 # https://github.com/tobymao/sqlglot/issues/4345
 # Wait for the issue to be resolved before removing this workaround
 def _build_date_delta_with_interval(
-    expression_class: t.Type[E],
+        expression_class: t.Type[E],
 ) -> t.Callable[[t.List], t.Optional[E]]:
     def _builder(args: t.List) -> t.Optional[E]:
         if len(args) < 2:
@@ -35,6 +35,7 @@ def _build_date_delta_with_interval(
         return expression_class(this=args[0], expression=expression, unit=unit_to_str(interval))
 
     return _builder
+
 
 # Note: This workaround only allows the syntax that has been adapted to the Source Dialect of Clickzetta to be hacked.
 # Anything that can be solved through expression will not be allowed here.
@@ -140,3 +141,97 @@ def _normalize_tuple_comparisons(expression: exp.Expression):
                 right_exprs[i - 1] = exp.Alias(this=right_expr, alias=exp.to_identifier(alias))
             else:
                 right_exprs[i - 1].set("alias", exp.to_identifier(alias))
+
+
+# Add UniqueKeyProperty expression class if it doesn't exist
+if not hasattr(exp, 'UniqueKeyProperty'):
+    class UniqueKeyProperty(exp.Property):
+        arg_types = {"expressions": True}
+
+
+    # Register it in the exp module
+    exp.UniqueKeyProperty = UniqueKeyProperty
+
+# Monkey patch Doris and StarRocks parsers to support UNIQUE KEY and BITMAP
+original_doris_parse_create = Doris.Parser._parse_create
+original_starrocks_parse_create = StarRocks.Parser._parse_create
+
+
+def _parse_unique_key(self):
+    """Parse UNIQUE KEY syntax."""
+    self._match_text_seq("KEY")
+    expressions = self._parse_wrapped_csv(self._parse_id_var, optional=False)
+    return self.expression(exp.UniqueKeyProperty, expressions=expressions)
+
+
+def _patched_doris_parse_create(self):
+    """Patched Doris _parse_create to support UNIQUE KEY and move it to schema."""
+    create = original_doris_parse_create(self)
+
+    # Move UniqueKey from properties to schema (similar to PrimaryKey handling in StarRocks)
+    if isinstance(create, exp.Create) and isinstance(create.this, exp.Schema):
+        props = create.args.get("properties")
+        if props:
+            unique_key = props.find(exp.UniqueKeyProperty)
+            if unique_key:
+                create.this.append("expressions", unique_key.pop())
+
+    return create
+
+
+def _patched_starrocks_parse_create(self):
+    """Patched StarRocks _parse_create to support UNIQUE KEY and move it to schema."""
+    create = original_starrocks_parse_create(self)
+
+    # Move UniqueKey from properties to schema (similar to PrimaryKey handling)
+    if isinstance(create, exp.Create) and isinstance(create.this, exp.Schema):
+        props = create.args.get("properties")
+        if props:
+            unique_key = props.find(exp.UniqueKeyProperty)
+            if unique_key:
+                create.this.append("expressions", unique_key.pop())
+
+    return create
+
+
+# Apply monkey patches
+Doris.Parser._parse_create = _patched_doris_parse_create
+Doris.Parser._parse_unique = _parse_unique_key
+StarRocks.Parser._parse_create = _patched_starrocks_parse_create
+StarRocks.Parser._parse_unique = _parse_unique_key
+
+# Add UNIQUE to PROPERTY_PARSERS for both dialects
+for dialect in [Doris, StarRocks]:
+    if hasattr(dialect.Parser, 'PROPERTY_PARSERS'):
+        dialect.Parser.PROPERTY_PARSERS = {
+            **dialect.Parser.PROPERTY_PARSERS,
+            "UNIQUE": lambda self: self._parse_unique(),
+        }
+
+# Add BITMAP data type support
+# We need to add BITMAP to the DataType.Type enum
+# Since we can't easily extend AutoName enums at runtime, we'll use a workaround
+# by treating BITMAP as a special identifier that gets mapped to a custom type
+
+# Store the original _parse_types method for Doris and StarRocks
+original_doris_parse_types = Doris.Parser._parse_types
+original_starrocks_parse_types = StarRocks.Parser._parse_types
+
+
+def _patched_parse_types(original_method):
+    """Wrap _parse_types to handle BITMAP as a special case."""
+
+    def wrapper(self, check_func=False, schema=False, allow_identifiers=True):
+        # Check if current token is BITMAP (as an identifier)
+        if self._match_text_seq("BITMAP"):
+            # Create a DataType with BITMAP as a custom type
+            # We'll map it to HLLSKETCH type internally since it's similar conceptually
+            return exp.DataType(this=exp.DataType.Type.HLLSKETCH, nested=False)
+        return original_method(self, check_func, schema, allow_identifiers)
+
+    return wrapper
+
+
+# Apply the wrapper to Doris and StarRocks parsers
+Doris.Parser._parse_types = _patched_parse_types(original_doris_parse_types)
+StarRocks.Parser._parse_types = _patched_parse_types(original_starrocks_parse_types)

--- a/tests/dialects/test_clickzetta.py
+++ b/tests/dialects/test_clickzetta.py
@@ -827,3 +827,17 @@ select j from a""",
                 "mysql": "CREATE TABLE test (id INT AUTO_INCREMENT, name STRING)",
             }
         )
+
+    def test_create_unique_key_with_bitmap(self):
+        """Test UNIQUE KEY syntax and BITMAP data type support from Doris/StarRocks."""
+        # Test simple BITMAP type conversion
+        simple_sql = "CREATE TABLE t (c1 BIGINT, c2 BITMAP NOT NULL) UNIQUE KEY(c1) DISTRIBUTED BY HASH(c1) BUCKETS 10"
+        self.validate_all(
+            "CREATE TABLE t (c1 BIGINT, c2 BITMAP NOT NULL, UNIQUE (c1)) CLUSTERED BY (c1) INTO 10 BUCKETS",
+            read={
+                "doris": simple_sql,
+            },
+            write={
+                "clickzetta": "CREATE TABLE t (c1 BIGINT, c2 BITMAP NOT NULL, UNIQUE (c1)) CLUSTERED BY (c1) INTO 10 BUCKETS",
+            },
+        )


### PR DESCRIPTION
UNIQUE KEY syntax and BITMAP data type support from Doris/StarRocks.
example：
```sql
CREATE TABLE t (c1 BIGINT, c2 BITMAP NOT NULL) UNIQUE KEY(c1) DISTRIBUTED BY HASH(c1) BUCKETS 10
```
It should be transpile to clickzetta sql:
```sql
CREATE TABLE t (c1 BIGINT, c2 BITMAP NOT NULL, UNIQUE (c1)) CLUSTERED BY (c1) INTO 10 BUCKETS
```
