### PR TITLE
[to #CZPDEV-20091] feat: Support Presto-DLC Special Syntax in ClickZetta

### DIFF
--- a/sqlglot/dialects/clickzetta.py
+++ b/sqlglot/dialects/clickzetta.py
@@ -3,16 +3,16 @@ from __future__ import annotations
 import logging
 import typing as t
 
-from sqlglot import exp
+from sqlglot import exp, time
 from sqlglot import transforms
 from sqlglot.dialects.dialect import (
     rename_func,
     if_sql, unit_to_str,
-    DATE_ADD_OR_SUB,
-)
+    DATE_ADD_OR_SUB)
 from sqlglot.dialects.hive import DATE_DELTA_INTERVAL
-from sqlglot.dialects.spark import Spark
+from sqlglot.dialects.hive import Hive
 from sqlglot.dialects.mysql import MySQL
+from sqlglot.dialects.spark import Spark
 from sqlglot.tokens import Tokenizer, TokenType
 
 logger = logging.getLogger("sqlglot")
@@ -84,6 +84,14 @@ def _anonymous_func(self: ClickZetta.Generator, expression: exp.Anonymous) -> st
         return f"LAST_DAY({self.sql(expression.expressions[0])})"
     elif upper_name == "TO_ISO8601":
         return f"DATE_FORMAT({self.sql(expression.expressions[0])}, 'yyyy-MM-dd\\'T\\'hh:mm:ss.SSSxxx')"
+    elif upper_name == "FORMAT_DATETIME":
+        current_format = self.sql(expression.expressions[1]).strip("'").strip("\"")
+        common_format = time.format_time(current_format, Hive.TIME_MAPPING, Hive.TIME_TRIE)
+        lakehouse_format = time.format_time(self.sql(common_format), ClickZetta.INVERSE_TIME_MAPPING,
+                                            ClickZetta.INVERSE_TIME_TRIE)
+        return f"DATE_FORMAT({self.sql(expression.expressions[0])}, '{self.sql(lakehouse_format)}')"
+    elif upper_name == "CURDATE":
+        return "CURRENT_DATE()"
     elif upper_name == "MAP_AGG":
         return f"MAP_FROM_ENTRIES(COLLECT_LIST(STRUCT({self.expressions(expression)})))"
     elif upper_name == "JSON_ARRAY_GET":
@@ -320,6 +328,15 @@ def _transform_group_sql(expression: exp.Expression) -> exp.Expression:
 def _json_extract(
     name: str, self: ClickZetta.Generator, expression: exp.JSONExtract | exp.JSONExtractScalar
 ) -> str:
+    # For JSONExtractScalar, use JSON_EXTRACT_STRING with JSON_PARSE
+    if isinstance(expression, exp.JSONExtractScalar):
+        # Always wrap the JSON argument with JSON_PARSE for JSONExtractScalar
+        json_arg = expression.this
+        if not isinstance(json_arg, exp.ParseJSON):
+            json_arg = exp.ParseJSON(this=json_arg)
+        return _build_parse_json_sql(
+            "JSON_EXTRACT_STRING", self, json_arg, expression.expression, expression.expressions
+        )
     return _build_parse_json_sql(
         name, self, expression.this, expression.expression, expression.expressions
     )
@@ -351,8 +368,11 @@ def _build_parse_json_sql(
         # If it is not a Literal type but a JsonPath, the $ prefix will be automatically added during translation
         path_str = self.sql(path)
 
+    # Handle JSON_PARSE wrapping
     if name.upper() != "GET_JSON_OBJECT" and isinstance(json, exp.Literal) and json.is_string:
-        return self.func(name, exp.ParseJSON(this=json), path_str, *exprs)
+        if not isinstance(json, exp.ParseJSON):
+            json = exp.ParseJSON(this=json)
+
     return self.func(name, json, path_str, *exprs)
 
 
@@ -368,6 +388,89 @@ class ClickZetta(Spark):
     # https://github.com/tobymao/sqlglot/issues/4013
     STRICT_JSON_PATH_SYNTAX = False
 
+    # ClickZetta date format patterns based on DateTimeFormatter
+    # Reference: https://yunqi.tech/documents/sql_functions/scalar_functions/datetime_functions/datetime_patterns
+    TIME_MAPPING = {
+        # Year
+        "yyyy": "%Y",  # 4-digit year (e.g., 2020)
+        "yy": "%y",    # 2-digit year (e.g., 20)
+
+        # Month
+        "MMMM": "%B",  # Full month name (e.g., July)
+        "MMM": "%b",   # Abbreviated month name (e.g., Jul)
+        "MM": "%m",    # 2-digit month (e.g., 07)
+        "M": "%-m",    # month without leading zero (e.g., 7)
+
+        # Day of month
+        "dd": "%d",    # 2-digit day (e.g., 28)
+        "d": "%-d",    # day without leading zero (e.g., 5)
+
+        # Day of year
+        "DD": "%j",    # day of year
+        "D": "%-j",    # day of year without leading zero
+
+        # Quarter
+        "QQQQ": "Q%q", # Quarter with text (e.g., 3rd quarter)
+        "QQQ": "Q%q",  # Quarter with Q prefix (e.g., Q3)
+        "QQ": "%q",    # 2-digit quarter (e.g., 03)
+        "Q": "%q",     # quarter (e.g., 3)
+
+        # Hour (24-hour)
+        "HH": "%H",    # 2-digit hour 0-23 (e.g., 00)
+        "H": "%-H",    # hour 0-23 without leading zero (e.g., 0)
+
+        # Hour (12-hour)
+        "hh": "%I",    # 2-digit hour 1-12 (e.g., 12)
+        "h": "%-I",    # hour 1-12 without leading zero (e.g., 12)
+
+        # Minute
+        "mm": "%M",    # 2-digit minute (e.g., 30)
+        "m": "%-M",    # minute without leading zero (e.g., 5)
+
+        # Second
+        "ss": "%S",    # 2-digit second (e.g., 55)
+        "s": "%-S",    # second without leading zero (e.g., 5)
+
+        # Fraction of second
+        "SSSSSS": "%f", # microseconds
+        "SSS": "%L",    # milliseconds
+        "S": "%L",      # fraction of second
+
+        # AM/PM
+        "a": "%p",     # AM/PM marker
+
+        # Week day
+        "EEEE": "%A",  # Full weekday name (e.g., Monday)
+        "EEE": "%a",   # Abbreviated weekday name (e.g., Mon)
+        "EE": "%a",    # Abbreviated weekday name
+        "E": "%a",     # Abbreviated weekday name
+
+        # Time zone
+        "VV": "%Z",    # Time zone ID (e.g., America/Los_Angeles)
+        "V": "%Z",     # Time zone ID
+        "zzzz": "%Z",  # Time zone name (e.g., Pacific Standard Time)
+        "zzz": "%Z",   # Time zone name (e.g., PST)
+        "zz": "%Z",    # Time zone name
+        "z": "%Z",     # Time zone name
+        "OOOO": "%z",  # Localized zone offset (e.g., GMT+08:00)
+        "O": "%z",     # Localized zone offset (e.g., GMT+8)
+        "XXXXX": "%z", # Zone offset with seconds (e.g., -08:30:15)
+        "XXXX": "%z",  # Zone offset (e.g., -08:30)
+        "XXX": "%z",   # Zone offset (e.g., -08:30)
+        "XX": "%z",    # Zone offset (e.g., -0830)
+        "X": "%z",     # Zone offset (e.g., -08)
+        "xxxxx": "%z", # Zone offset with seconds
+        "xxxx": "%z",  # Zone offset
+        "xxx": "%z",   # Zone offset
+        "xx": "%z",    # Zone offset
+        "x": "%z",     # Zone offset
+        "ZZZZZ": "%z", # Zone offset (e.g., -08:30:15)
+        "ZZZZ": "%z",  # Zone offset (e.g., -08:00)
+        "ZZZ": "%z",   # Zone offset (e.g., -08:00)
+        "ZZ": "%z",    # Zone offset (e.g., -0800)
+        "Z": "%z",     # Zone offset (e.g., +0000)
+    }
+
     class Tokenizer(Spark.Tokenizer):
         KEYWORDS = {
             **Tokenizer.KEYWORDS,
@@ -376,6 +479,7 @@ class ClickZetta(Spark):
             "SEPARATOR": TokenType.SEPARATOR,
             "SHOW USER": TokenType.COMMAND,
             "REVOKE": TokenType.COMMAND,
+            "SIGNED": TokenType.BIGINT
         }
 
     class Parser(Spark.Parser):
@@ -472,6 +576,7 @@ class ClickZetta(Spark):
             exp.DataType.Type.HLLSKETCH: "BITMAP",
         }
 
+
         PROPERTIES_LOCATION = {
             **Spark.Generator.PROPERTIES_LOCATION,
             exp.PrimaryKey: exp.Properties.Location.POST_NAME,
@@ -538,8 +643,18 @@ class ClickZetta(Spark):
 
         def datatype_sql(self, expression: exp.DataType) -> str:
             """Remove unsupported type params from int types: eg. int(10) -> int
-            Remove type param from enum series since it will be mapped as STRING."""
+            Remove type param from enum series since it will be mapped as STRING.
+            Map SIGNED to BIGINT."""
             type_value = expression.this
+
+            # Handle SIGNED as a user-defined type (for Presto compatibility)
+            # Check the 'kind' attribute for USERDEFINED types
+            kind = expression.args.get("kind")
+            if kind and isinstance(kind, str) and kind.upper() == "SIGNED":
+                return "BIGINT"
+            if isinstance(type_value, str) and type_value.upper() == "SIGNED":
+                return "BIGINT"
+
             type_sql = (
                 self.TYPE_MAPPING.get(type_value, type_value.value)
                 if isinstance(type_value, exp.DataType.Type)

--- a/sqlglot/dialects/clickzetta.py
+++ b/sqlglot/dialects/clickzetta.py
@@ -689,22 +689,6 @@ class ClickZetta(Spark):
             if isinstance(type_value, str) and type_value.upper() == "SIGNED":
                 return "BIGINT"
 
-            type_sql = (
-                self.TYPE_MAPPING.get(type_value, type_value.value)
-                if isinstance(type_value, exp.DataType.Type)
-                else type_value
-            )
-            if type_value in exp.DataType.INTEGER_TYPES or type_value in {
-                exp.DataType.Type.UTINYINT,
-                exp.DataType.Type.USMALLINT,
-                exp.DataType.Type.UMEDIUMINT,
-                exp.DataType.Type.UINT,
-                exp.DataType.Type.UINT128,
-                exp.DataType.Type.UINT256,
-                exp.DataType.Type.ENUM,
-                exp.DataType.Type.FLOAT,
-                exp.DataType.Type.DOUBLE,
-            }:
             # Check if type_value is an enum or a string
             if isinstance(type_value, exp.DataType.Type):
                 type_sql = self.TYPE_MAPPING.get(type_value, type_value.value)

--- a/sqlglot/local_clickzetta_settings.py
+++ b/sqlglot/local_clickzetta_settings.py
@@ -40,6 +40,30 @@ def _build_date_delta_with_interval(
 
 # Note: This workaround only allows the syntax that has been adapted to the Source Dialect of Clickzetta to be hacked.
 # Anything that can be solved through expression will not be allowed here.
+def _presto_date_add_parser(args: t.List) -> exp.DateAdd:
+    """Support both 2-arg and 3-arg versions of date_add for presto-dlc.
+
+    2-arg version (like MySQL): date_add(date, days)
+    3-arg version (standard Presto): date_add(unit, amount, date)
+    """
+    if len(args) == 2:
+        # 2-arg version: date_add(date, days) - assume unit is DAY
+        return exp.DateAdd(
+            this=args[0],
+            expression=args[1],
+            unit=exp.Var(this="DAY")
+        )
+    elif len(args) == 3:
+        # 3-arg version: date_add(unit, amount, date)
+        return exp.DateAdd(
+            this=args[2],
+            expression=args[1],
+            unit=args[0]
+        )
+    else:
+        # Fallback for unexpected arg counts
+        return None
+
 for dialect in [MySQL, Presto, Trino, Athena, StarRocks, Doris]:
     dialect.Parser.FUNCTIONS["DATE_FORMAT"] = lambda args: exp.Anonymous(
         this="DATE_FORMAT_MYSQL", expressions=args
@@ -49,6 +73,14 @@ for dialect in [MySQL, Presto, Trino, Athena, StarRocks, Doris]:
     )
     dialect.Parser.FUNCTIONS["AES_ENCRYPT"] = lambda args: exp.Anonymous(
         this="AES_ENCRYPT_MYSQL", expressions=args
+    )
+
+# Override date_add for Presto-based dialects to support both 2 and 3 parameters
+for dialect in [Presto, Trino, Athena]:
+    dialect.Parser.FUNCTIONS["DATE_ADD"] = _presto_date_add_parser
+    # Convert Presto's TRUNCATE to TRUNCATE_PRESTO to distinguish from ClickZetta's TRUNCATE
+    dialect.Parser.FUNCTIONS["TRUNCATE"] = lambda args: exp.Anonymous(
+        this="TRUNCATE_PRESTO", expressions=args
     )
 
 ClickHouse.Parser.FUNCTIONS["FORMATDATETIME"] = lambda args: exp.Anonymous(

--- a/tests/dialects/test_clickzetta.py
+++ b/tests/dialects/test_clickzetta.py
@@ -1150,7 +1150,9 @@ PARTITION p201702 VALUES LESS THAN ('2017-03-01')
         self.validate_all(
             "SELECT CAST(mobile AS BIGINT) AS mobile_hash",
             read={"presto": "SELECT CAST(mobile AS SIGNED) AS mobile_hash"},
-            write={"clickzetta": "SELECT CAST(mobile AS BIGINT) AS mobile_hash"},
+            write={"clickzetta": "SELECT CAST(mobile AS BIGINT) AS mobile_hash"}
+        )
+
     def test_aggregate_key(self):
         """Test AGGREGATE KEY syntax from Doris/StarRocks.
 

--- a/tests/dialects/test_clickzetta.py
+++ b/tests/dialects/test_clickzetta.py
@@ -742,6 +742,8 @@ select j from a""",
             "SELECT DATE_TRUNC('HOUR', TIMESTAMP '2022-01-01 12:34:56')",
             "SELECT DATE_TRUNC('MINUTE', TIMESTAMP '2022-01-01 12:34:56')",
             "SELECT DATE_TRUNC('SECOND', TIMESTAMP '2022-01-01 12:34:56')",
+            # presto-dlc transpile to clickzetta need use single quote for date part
+            "SELECT DATE_TRUNC(\"SECOND\", TIMESTAMP '2022-01-01 12:34:56')",
         ]
 
         except_sqls = [
@@ -750,6 +752,7 @@ select j from a""",
             "SELECT DATE_TRUNC('DAY', CAST('2022-01-01' AS DATE))",
             "SELECT DATE_TRUNC('HOUR', CAST('2022-01-01 12:34:56' AS TIMESTAMP))",
             "SELECT DATE_TRUNC('MINUTE', CAST('2022-01-01 12:34:56' AS TIMESTAMP))",
+            "SELECT DATE_TRUNC('SECOND', CAST('2022-01-01 12:34:56' AS TIMESTAMP))",
             "SELECT DATE_TRUNC('SECOND', CAST('2022-01-01 12:34:56' AS TIMESTAMP))",
         ]
 
@@ -961,4 +964,63 @@ PARTITION p201701 VALUES LESS THAN ('2017-02-01'),
 PARTITION p201702 VALUES LESS THAN ('2017-03-01')
 )""",
             },
+        )
+
+    def test_presto_syntax_support(self):
+        """Test new Presto-DLC specific syntax support."""
+        # Test format_datetime function
+        self.validate_all(
+            "SELECT DATE_FORMAT(CURRENT_DATE, 'yyyyMMdd')",
+            read={"presto": "SELECT format_datetime(current_date(), 'YYYYMMdd')"},
+            write={"clickzetta": "SELECT DATE_FORMAT(CAST(CURRENT_DATE AS TIMESTAMP), 'yyyyMMdd')"},
+        )
+
+        # Test curdate function
+        self.validate_all(
+            "SELECT CURRENT_DATE()",
+            read={"presto": "SELECT curdate()"},
+            write={"clickzetta": "SELECT CURRENT_DATE"},
+        )
+
+        # Test date_add with 2 parameters (MySQL-like syntax)
+        self.validate_all(
+            "SELECT OrderId, TIMESTAMP_OR_DATE_ADD('DAY', 1, OrderDate) AS OrderPayDate FROM Orders",
+            read={"presto": "SELECT OrderId, DATE_ADD(OrderDate, 1) AS OrderPayDate FROM Orders"},
+            write={"clickzetta": "SELECT OrderId, TIMESTAMP_OR_DATE_ADD('DAY', 1, OrderDate) AS OrderPayDate FROM Orders"},
+        )
+
+        # Test date_add with 3 parameters (standard Presto syntax)
+        self.validate_all(
+            "SELECT TIMESTAMP_OR_DATE_ADD('DAY', 1, CURRENT_DATE)",
+            read={"presto": "SELECT date_add('day', 1, current_date())"},
+            write={"clickzetta": "SELECT TIMESTAMP_OR_DATE_ADD('DAY', 1, CURRENT_DATE)"},
+        )
+
+        # Test complex nested date_add and format_datetime
+        self.validate_all(
+            "SELECT TIMESTAMP_OR_DATE_ADD('DAY', 364, DATE_FORMAT(TIMESTAMP_OR_DATE_ADD('DAY', 1, CURRENT_DATE), 'yyyyMMdd'))",
+            read={"presto": "SELECT date_add(format_datetime(date_add(current_date(), 1), 'yyyyMMdd'), 364)"},
+            write={"clickzetta": "SELECT TIMESTAMP_OR_DATE_ADD('DAY', 364, DATE_FORMAT(CAST(TIMESTAMP_OR_DATE_ADD('DAY', 1, CURRENT_DATE) AS TIMESTAMP), 'yyyyMMdd'))"},
+        )
+
+        # Test json_extract_scalar to json_extract_string with json_parse
+        self.validate_all(
+            """SELECT JSON_EXTRACT_STRING(JSON '{"a": {"b": {"c": "d"}}}', '$.a.b.c') AS extracted_value""",
+            read={"presto": """SELECT json_extract_scalar('{"a": {"b": {"c": "d"}}}', '$.a.b.c') AS extracted_value"""},
+            write={"clickzetta": """SELECT JSON_EXTRACT_STRING(JSON '{"a": {"b": {"c": "d"}}}', '$.a.b.c') AS extracted_value"""},
+        )
+
+        # Test truncate function conversion to truncate_presto
+        self.validate_all(
+            "SELECT TRUNCATE_PRESTO(123.456)",
+            read={"presto": "SELECT truncate(123.456)"},
+            write={"clickzetta": "SELECT TRUNCATE_PRESTO(123.456)"},
+        )
+
+        # Test SIGNED type conversion to BIGINT (Presto->ClickZetta)
+        # We only test read direction since Presto converts CAST to TRY_CAST in write
+        self.validate_all(
+            "SELECT CAST(mobile AS BIGINT) AS mobile_hash",
+            read={"presto": "SELECT CAST(mobile AS SIGNED) AS mobile_hash"},
+            write={"clickzetta": "SELECT CAST(mobile AS BIGINT) AS mobile_hash"},
         )


### PR DESCRIPTION
# feat: Support Presto-DLC Special Syntax in ClickZetta

## Summary
This PR adds support for several Presto-DLC (Data Lake Connector) specific syntax features to ensure proper SQL translation from Presto to ClickZetta.

## Changes

### 1. **FORMAT_DATETIME Function Support**
- Maps `format_datetime()` to `DATE_FORMAT()` for proper datetime formatting
- Ensures consistent date formatting across dialects

### 2. **CURDATE Function Support**
- Translates `curdate()` to `CURRENT_DATE` in ClickZetta dialect

### 3. **Enhanced DATE_ADD Function**
- Supports both 2-parameter and 3-parameter versions of `date_add`:
  - 2-parameter: `date_add(date, days)` - MySQL-like syntax (assumes DAY unit)
  - 3-parameter: `date_add(unit, amount, date)` - Standard Presto syntax

### 4. **JSON_EXTRACT_SCALAR Enhancement**
- Converts `json_extract_scalar(str, path)` to `json_extract_string(json_parse(str), path)`

### 5. **TRUNCATE Function Differentiation**
- Maps Presto's `truncate()` to `truncate_presto()` to distinguish from ClickZetta's built-in `TRUNCATE` function
- Prevents function name conflicts between dialects

### 6. **SIGNED Type Conversion**
- Automatically converts `SIGNED` type to `BIGINT` when transpiling from Presto
- Handles user-defined type `SIGNED` properly
