### PR TITLE
[to #CZPDEV-20091] fix: Decode unicode escapes in ClickZetta string l…

### DIFF
--- a/sqlglot/dialects/clickzetta.py
+++ b/sqlglot/dialects/clickzetta.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import typing as t
 
 from sqlglot import exp, time
@@ -21,6 +22,21 @@ try:
     from sqlglot import local_clickzetta_settings
 except ImportError as e:
     logger.error(f"Failed to import local_clickzetta_settings, reason: {e}")
+
+
+# \uXXXX(16 位)和 \UXXXXXXXX(32 位)unicode 转义。
+# databricks/spark 的 tokenizer 不识别 \u,会把反斜杠原样留进 AST,
+# 生成阶段再被无条件翻倍成 \\u200B,破坏字符串语义。这里在写出 ClickZetta
+# 之前先把这些序列解码成真实字符,与 \n \t 等已支持的转义处理保持一致。
+_UNICODE_ESCAPE_RE = re.compile(r"\\u([0-9A-Fa-f]{4})|\\U([0-9A-Fa-f]{8})")
+
+
+def _decode_unicode_escapes(text: str) -> str:
+    def repl(match: re.Match) -> str:
+        hex_code = match.group(1) or match.group(2)
+        return chr(int(hex_code, 16))
+
+    return _UNICODE_ESCAPE_RE.sub(repl, text)
 
 
 def _anonymous_agg_func(self: ClickZetta.Generator, expression: exp.AnonymousAggFunc) -> str:
@@ -744,3 +760,8 @@ class ClickZetta(Spark):
                 expression = ensure_bools(expression)
 
             return expression
+
+        def escape_str(self, text: str, escape_backslash: bool = True) -> str:
+            return super().escape_str(
+                _decode_unicode_escapes(text), escape_backslash=escape_backslash
+            )

--- a/tests/dialects/test_clickzetta.py
+++ b/tests/dialects/test_clickzetta.py
@@ -1361,3 +1361,31 @@ DISTRIBUTED BY HASH(id) BUCKETS 10""",
                 "doris": "SELECT unix_timestamp()",
             },
         )
+
+    def test_unicode_escape_in_string(self):
+        # SHOW CREATE TABLE 返回的视图 SQL 里 ​ 是字面反斜杠转义写法。
+        # databricks/spark 语义里 \uXXXX 是 unicode 转义,应还原成真实字符,
+        # 而不是把反斜杠翻倍成 \\u200B(否则字符串语义被破坏)。
+        zwsp = "​"  # 真实的零宽空格字符
+        self.validate_all(
+            f"SELECT 'a{zwsp}b' AS col",
+            read={
+                "databricks": "SELECT 'a\\u200Bb' AS col",
+                "spark": "SELECT 'a\\u200Bb' AS col",
+            },
+        )
+        # 32 位 \UXXXXXXXX 形式(emoji)
+        emoji = "\U0001F600"
+        self.validate_all(
+            f"SELECT '{emoji}' AS col",
+            read={
+                "databricks": "SELECT '\\U0001F600' AS col",
+            },
+        )
+        # 普通反斜杠(非 unicode 转义)保持原样翻倍语义不变
+        self.validate_all(
+            "SELECT 'C:\\\\temp' AS col",
+            read={
+                "databricks": "SELECT 'C:\\\\temp' AS col",
+            },
+        )


### PR DESCRIPTION
…iterals

Databricks/Spark 语义里 \uXXXX / \UXXXXXXXX 是 unicode 转义,ClickZetta 生成阶段却把反斜杠无条件翻倍成字面 \\u200B,破坏了字符串语义。在写出
ClickZetta 前先把这些序列解码成真实字符,与 \n \t 等已支持的转义保持一致。